### PR TITLE
Feature/create olympiad endpoint

### DIFF
--- a/app/Http/Controllers/Api/OlympiadController.php
+++ b/app/Http/Controllers/Api/OlympiadController.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+use App\Models\Olympiad;
+
+class OlympiadController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $olympiads = Olympiad::all();
+
+        if ($olympiads->isEmpty()) {
+            $data = [
+                'message' => 'No olympiads found',
+                'status' => 404
+            ];
+            return response()->json($data, 404);
+        }
+
+        $data = [
+            'olympiads' => $olympiads,
+            'stauts' => 200
+
+        ];
+
+        return response()->json($data, 200);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string|max:255',
+            'edition' => 'required|string|max:20|unique:olympiads,edition',
+            'start_date' => 'required|date',
+            'end_date' => 'required|date|after:start_date',
+        ]);
+
+        // Data validation
+        if ($validator->fails()) {
+            $data = [
+                'message' => 'Error in data validation',
+                'error' => $validator->errors(),
+                'status' => 400
+            ];
+            return response()->json($data, 400);
+        }
+
+        $olympiad = Olympiad::create([
+            'name' => $request->name,
+            'edition' => $request->edition,
+            'start_date' => $request->start_date,
+            'end_date' => $request->end_date
+        ]);
+
+        // If the Olympiad creation fails
+        if (!$olympiad) {
+            $data = [
+                'message' => 'Error creating the Olympiad',
+                'status' => 500
+            ];
+            return response()->json($data, 500);
+        }
+
+        // If the Olympiad creation is successful
+        $data = [
+            'olympiad' => $olympiad,
+            'status' => 201
+        ];
+
+        return response()->json($data, 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        $olympiad = Olympiad::find($id);
+
+        if (!$olympiad) {
+            $data = [
+                'message' => 'Olympiad not found',
+                'status' => 404
+            ];
+            return response()->json($data, 404);
+        };
+
+        $data = [
+            'olympiad' => $olympiad,
+            'status' => 200
+        ];
+
+        return response()->json($data, 200);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/Api/OlympiadController.php
+++ b/app/Http/Controllers/Api/OlympiadController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
 
 use App\Models\Olympiad;
 
@@ -119,9 +120,15 @@ class OlympiadController extends Controller
             return response()->json($data, 404);
         };
 
+        // Rule set to ignore the edition if it is the same as the one sent
         $validator = Validator::make($request->all(), [
             'name' => 'required|string|max:255',
-            'edition' => 'required|string|max:20|unique:olympiads,edition',
+            'edition' => [
+                'required',
+                'string',
+                'max:20',
+                Rule::unique('olympiads', 'edition')->ignore($olympiad->id),
+            ],
             'start_date' => 'required|date',
             'end_date' => 'required|date|after:start_date',
         ]);
@@ -156,6 +163,23 @@ class OlympiadController extends Controller
      */
     public function destroy(string $id)
     {
-        //
+        $olympiad = Olympiad::find($id);
+
+        if (!$olympiad) {
+            $data = [
+                'message' => 'Olympiad not found',
+                'status' => 404
+            ];
+            return response()->json($data, 404);
+        };
+
+        $olympiad->delete();
+
+        $data = [
+            'message' => 'Olympiad deleted',
+            'status' => 200
+        ];
+
+        return response()->json($data, 200);
     }
 }

--- a/app/Http/Controllers/Api/OlympiadController.php
+++ b/app/Http/Controllers/Api/OlympiadController.php
@@ -39,6 +39,7 @@ class OlympiadController extends Controller
      */
     public function store(Request $request)
     {
+        // Data validation
         $validator = Validator::make($request->all(), [
             'name' => 'required|string|max:255',
             'edition' => 'required|string|max:20|unique:olympiads,edition',
@@ -46,7 +47,6 @@ class OlympiadController extends Controller
             'end_date' => 'required|date|after:start_date',
         ]);
 
-        // Data validation
         if ($validator->fails()) {
             $data = [
                 'message' => 'Error in data validation',
@@ -109,7 +109,46 @@ class OlympiadController extends Controller
      */
     public function update(Request $request, string $id)
     {
-        //
+        $olympiad = Olympiad::find($id);
+
+        if (!$olympiad) {
+            $data = [
+                'message' => 'Olympiad not found',
+                'status' => 404
+            ];
+            return response()->json($data, 404);
+        };
+
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string|max:255',
+            'edition' => 'required|string|max:20|unique:olympiads,edition',
+            'start_date' => 'required|date',
+            'end_date' => 'required|date|after:start_date',
+        ]);
+
+        if ($validator->fails()) {
+            $data = [
+                'message' => 'Error in data validation',
+                'error' => $validator->errors(),
+                'status' => 400
+            ];
+            return response()->json($data, 400);
+        }
+
+        $olympiad->name = $request->name;
+        $olympiad->edition = $request->edition;
+        $olympiad->start_date = $request->start_date;
+        $olympiad->end_date = $request->end_date;
+
+        $olympiad->save();
+
+        $data = [
+            'message' => 'Olympiad updated',
+            'olympiad' => $olympiad,
+            'status' => 200
+        ];
+
+        return response()->json($data, 200);
     }
 
     /**

--- a/app/Models/Olympiad.php
+++ b/app/Models/Olympiad.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Olympiad extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'edition',
+        'start_date',
+        'end_date',
+    ];
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^11.31",
+        "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.9"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "626b9e7ddd47fb7eff9aaa53cce0c9ad",
+    "content-hash": "f60f8b6e279e6de64f92f6b9fb420141",
     "packages": [
         {
             "name": "brick/math",
@@ -1326,6 +1326,70 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.3.6"
             },
             "time": "2025-07-07T14:17:42+00:00"
+        },
+        {
+            "name": "laravel/sanctum",
+            "version": "v4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sanctum.git",
+                "reference": "fd6df4f79f48a72992e8d29a9c0ee25422a0d677"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/fd6df4f79f48a72992e8d29a9c0ee25422a0d677",
+                "reference": "fd6df4f79f48a72992e8d29a9c0ee25422a0d677",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^11.0|^12.0",
+                "illuminate/contracts": "^11.0|^12.0",
+                "illuminate/database": "^11.0|^12.0",
+                "illuminate/support": "^11.0|^12.0",
+                "php": "^8.2",
+                "symfony/console": "^7.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^9.0|^10.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sanctum\\SanctumServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sanctum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Sanctum provides a featherweight authentication system for SPAs and simple APIs.",
+            "keywords": [
+                "auth",
+                "laravel",
+                "sanctum"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sanctum/issues",
+                "source": "https://github.com/laravel/sanctum"
+            },
+            "time": "2025-07-09T19:45:24+00:00"
         },
         {
             "name": "laravel/serializable-closure",

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -1,0 +1,84 @@
+<?php
+
+use Laravel\Sanctum\Sanctum;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Stateful Domains
+    |--------------------------------------------------------------------------
+    |
+    | Requests from the following domains / hosts will receive stateful API
+    | authentication cookies. Typically, these should include your local
+    | and production domains which access your API via a frontend SPA.
+    |
+    */
+
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+        '%s%s',
+        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        Sanctum::currentApplicationUrlWithPort(),
+        // Sanctum::currentRequestHost(),
+    ))),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Guards
+    |--------------------------------------------------------------------------
+    |
+    | This array contains the authentication guards that will be checked when
+    | Sanctum is trying to authenticate a request. If none of these guards
+    | are able to authenticate the request, Sanctum will use the bearer
+    | token that's present on an incoming request for authentication.
+    |
+    */
+
+    'guard' => ['web'],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Expiration Minutes
+    |--------------------------------------------------------------------------
+    |
+    | This value controls the number of minutes until an issued token will be
+    | considered expired. This will override any values set in the token's
+    | "expires_at" attribute, but first-party sessions are not affected.
+    |
+    */
+
+    'expiration' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Token Prefix
+    |--------------------------------------------------------------------------
+    |
+    | Sanctum can prefix new tokens in order to take advantage of numerous
+    | security scanning initiatives maintained by open source platforms
+    | that notify developers if they commit tokens into repositories.
+    |
+    | See: https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning
+    |
+    */
+
+    'token_prefix' => env('SANCTUM_TOKEN_PREFIX', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Middleware
+    |--------------------------------------------------------------------------
+    |
+    | When authenticating your first-party SPA with Sanctum you may need to
+    | customize some of the middleware Sanctum uses while processing the
+    | request. You may change the middleware listed below as required.
+    |
+    */
+
+    'middleware' => [
+        'authenticate_session' => Laravel\Sanctum\Http\Middleware\AuthenticateSession::class,
+        'encrypt_cookies' => Illuminate\Cookie\Middleware\EncryptCookies::class,
+        'validate_csrf_token' => Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
+    ],
+
+];

--- a/database/migrations/2025_09_20_064231_create_personal_access_tokens_table.php
+++ b/database/migrations/2025_09_20_064231_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->text('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/database/migrations/2025_09_20_065008_create_olympiads_table.php
+++ b/database/migrations/2025_09_20_065008_create_olympiads_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('olympiads', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('edition'); // Changed "period" for "edition", I think it is a better term to refer "gestión"
+            $table->date('start_date');
+            $table->date('end_date');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('olympiads');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,11 +18,7 @@ Route::get('/olympiads/{id}', [OlympiadController::class, 'show']);
 // POST /olympiads/
 Route::post('/olympiads', [OlympiadController::class, 'store']);
 // PUT /olympiads/{id}
-Route::put('/olympiads', function (){
-    return 'Placeholder PUT olympiad';
-});
+Route::put('/olympiads/{id}', [OlympiadController::class, 'update']);
 // TO DO: PATCH/olympiads/{id}
 // DELETE /olympiads/{id}
-Route::delete('/olympiads', function (){
-    return 'Placeholder DELETE olympiad';
-});
+Route::delete('/olympiads/{id}', [OlympiadController::class, 'destroy']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+// Controllers here:
+use App\Http\Controllers\Api\OlympiadController;
+
+Route::get('/user', function (Request $request) {
+    return $request->user();
+})->middleware('auth:sanctum');
+
+// <--- CRUD Olympiad --->
+// GET /olympiads
+Route::get('/olympiads', [OlympiadController::class, 'index']);
+// GET /olympiads/{id}
+Route::get('/olympiads/{id}', [OlympiadController::class, 'show']);
+// POST /olympiads/
+Route::post('/olympiads', [OlympiadController::class, 'store']);
+// PUT /olympiads/{id}
+Route::put('/olympiads', function (){
+    return 'Placeholder PUT olympiad';
+});
+// TO DO: PATCH/olympiads/{id}
+// DELETE /olympiads/{id}
+Route::delete('/olympiads', function (){
+    return 'Placeholder DELETE olympiad';
+});


### PR DESCRIPTION
Main methods (get, get{id}, update and delete) for the /olympiads endpoint created.
Current validations:

- Name: required
- Edition (the term we'll use to refer to "gestión" from now on) max length name: 20 characters and it's unique, also this field is required
- Stat date: required and must be a date
- End date: required and must be a date after the Start date.

Also, I added the api routing configuration and some commentaries to make the code more understandable.