### PR TITLE
feat: custom areas request for Olympiad added.

### DIFF
--- a/app/Http/Controllers/Api/OlympiadController.php
+++ b/app/Http/Controllers/Api/OlympiadController.php
@@ -62,7 +62,13 @@ class OlympiadController extends Controller
             return response()->json($data, 400);
         }
 
-        $olympiad = Olympiad::createWithDefaults($request->all());
+        $olympiad = Olympiad::create([
+            'name' => $request->name,
+            'edition' => $request->edition,
+            'start_date' => $request->start_date,
+            'end_date' => $request->end_date,
+            'number_of_phases' => $request->number_of_phases,
+        ]);
 
         // If the Olympiad creation fails
         if (!$olympiad) {
@@ -178,5 +184,38 @@ class OlympiadController extends Controller
         ];
 
         return response()->json($data, 200);
+    }
+
+    public function assignAreas(Request $request, $id)
+    {
+        $olympiad = Olympiad::find($id);
+
+        if (!$olympiad) {
+            return response()->json([
+                'message' => 'Olympiad not found',
+                'status' => 404
+            ], 404);
+        }
+
+        // Data validation
+        $validator = Validator::make($request->all(), [
+            'areas' => 'required|array|min:1',
+            'areas.*' => 'required|string|max:25'
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Error in data validation',
+                'error' => $validator->errors(),
+                'status' => 400
+            ], 400);
+        }
+
+        $olympiad = $olympiad->assignAreas($request->areas);
+
+        return response()->json([
+            'message' => 'Areas assigned successfully',
+            'data' => $olympiad,
+        ], 200);
     }
 }

--- a/app/Models/Olympiad.php
+++ b/app/Models/Olympiad.php
@@ -38,46 +38,38 @@ class Olympiad extends Model
             'id');                      // PK in olympiad_area
     }
 
-    public static function createWithDefaults(array $data) {
-        $olympiad = self::create($data);
-
-        // Default Areas
-        $defaultAreas = ['Matemáticas', 'Física', 'Química', 'Informática'];
+    public function assignAreas(array $areaNames) {
         $areaIds = [];
 
-        foreach ($defaultAreas as $areaName) {
+        // Create or get areas
+        foreach ($areaNames as $areaName) {
             $area = Area::firstOrCreate(['name' => $areaName]);
             $areaIds[] = $area->id;
         }
 
         // Relate Olympiad with Areas
-        $olympiad->areas()->sync($areaIds);
+        $this->areas()->sync($areaIds);
 
-        // Default Phases (number_of_phases)
-        $phaseIds = [];
-        for ($i = 1; $i <= $olympiad->number_of_phases; $i++) {
-            $phase = Phase::firstOrCreate([
-                'name' => 'Fase ' . $i,
-                'order' => $i,
-            ]);
-            $phaseIds[] = $phase->id;
-        }
-
-        // Relate each OlympiadArea with all Phases
+        // Create phases for each area
         foreach ($areaIds as $areaId) {
-            // Get the pivot relationship between Olympiad and Area
-            $olympiadArea = OlympiadArea::where('olympiad_id', $olympiad->id)
+            $olympiadArea = OlympiadArea::where('olympiad_id', $this->id)
                 ->where('area_id', $areaId)
                 ->first();
 
-            foreach ($phaseIds as $phaseId) {
+            // Create phases for this area
+            for ($i = 1; $i <= $this->number_of_phases; $i++) {
+                $phase = Phase::firstOrCreate([
+                    'name' => 'Fase ' . $i,
+                    'order' => $i,
+                ]);
+
                 OlympiadAreaPhase::firstOrCreate([
                     'olympiad_area_id' => $olympiadArea->id,
-                    'phase_id' => $phaseId,
+                    'phase_id' => $phase->id,
                 ]);
             }
         }
 
-        return $olympiad->load('areas', 'phases');
+        return $this->load('areas', 'phases');
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,42 +16,26 @@ Route::get('/user', function (Request $request) {
 })->middleware('auth:sanctum');
 
 // <--- CRUD Olympiad --->
-// GET /olympiads
 Route::get('/olympiads', [OlympiadController::class, 'index']);
-// GET /olympiads/{id}
 Route::get('/olympiads/{id}', [OlympiadController::class, 'show']);
-// POST /olympiads/
 Route::post('/olympiads', [OlympiadController::class, 'store']);
-// PUT /olympiads/{id}
 Route::put('/olympiads/{id}', [OlympiadController::class, 'update']);
-// TO DO: PATCH/olympiads/{id}
-// DELETE /olympiads/{id}
 Route::delete('/olympiads/{id}', [OlympiadController::class, 'destroy']);
+// Assign areas to olympiad
+Route::post('/olympiads/{id}/areas', [OlympiadController::class, 'assignAreas']);
 
 // <--- CRUD Area --->
-// GET /areas
 Route::get('/areas', [AreaController::class, 'index']);
-// GET /areas/{id}
 Route::get('/areas/{id}', [AreaController::class, 'show']);
-// POST /areas/
 Route::post('/areas', [AreaController::class, 'store']);
-// PUT /areas/{id}
 Route::put('/areas/{id}', [AreaController::class, 'update']);
-// TO DO: PATCH/areas/{id}
-// DELETE /areas/{id}
 Route::delete('/areas/{id}', [AreaController::class, 'destroy']);
 
 // <--- CRUD Phase --->
-// GET /phases
 Route::get('/phases', [PhaseController::class, 'index']);
-// GET /phases/{id}
 Route::get('/phases/{id}', [PhaseController::class, 'show']);
-// POST /phases/
 Route::post('/phases', [PhaseController::class, 'store']);
-// PUT /phases/{id}
 Route::put('/phases/{id}', [PhaseController::class, 'update']);
-// TO DO: PATCH/phases/{id}
-// DELETE /phases/{id}
 Route::delete('/phases/{id}', [PhaseController::class, 'destroy']);
 
 // login


### PR DESCRIPTION
Now at the moment of creating a new Olympiad, it only takes the number of phases as a field and doesn't create areas by default.

To assign areas to this Olympiad, an endpoint was created (/api/olympiad/{id}/areas), and it receives the "areas" field and an array of the areas' names.