### PR TITLE
feat: competitor automatic classification when phase ends

### DIFF
--- a/app/Http/Controllers/Api/EvaluationController.php
+++ b/app/Http/Controllers/Api/EvaluationController.php
@@ -6,6 +6,9 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Validator;
 use App\Models\Evaluation;
+use App\Models\OlympiadArea;
+use App\Models\OlympiadAreaPhase;
+use App\Models\Phase;
 use Illuminate\Http\JsonResponse;
 use Carbon\Carbon;
 
@@ -101,7 +104,168 @@ class EvaluationController extends Controller
             'last_updated_at' => $maxUpdatedAt,
             'status' => 200
         ];
-        
+
         return response()->json($data, 200);
+    }
+
+    /**
+     * Get competitors by phase with eligibility logic
+     */
+    public function getCompetitorsByPhase(Request $request, $olympiadId, $areaId, $phaseId): JsonResponse
+    {
+        // Verificar que existe la relación olympiad_area
+        $olympiadArea = OlympiadArea::where('olympiad_id', $olympiadId)
+            ->where('area_id', $areaId)
+            ->first();
+
+        if (!$olympiadArea) {
+            return response()->json([
+                'message' => 'Olympiad area relationship not found',
+                'status' => 404
+            ], 404);
+        }
+
+        $olympiadAreaPhase = OlympiadAreaPhase::where('olympiad_area_id', $olympiadArea->id)
+            ->where('phase_id', $phaseId)
+            ->first();
+
+        if (!$olympiadAreaPhase) {
+            return response()->json([
+                'message' => 'Phase not found for this olympiad area',
+                'status' => 404
+            ], 404);
+        }
+
+        // Obtener competidores elegibles para esta fase
+        $eligibleCompetitors = $this->getEligibleCompetitors($olympiadAreaPhase, $phaseId);
+
+        return response()->json([
+            'competitors' => $eligibleCompetitors,
+            'olympiad_id' => $olympiadId,
+            'area_id' => $areaId,
+            'phase_id' => $phaseId,
+            'status' => 200
+        ], 200);
+    }
+
+    /**
+     * Update classification status manually
+     */
+    public function updateClassificationStatus(Request $request, $id): JsonResponse
+    {
+        $evaluation = Evaluation::find($id);
+
+        if (!$evaluation) {
+            return response()->json([
+                'message' => 'Evaluation not found',
+                'status' => 404
+            ], 404);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'classification_status' => 'required|string|in:clasificado,desclasificado,descalificado',
+            'classification_place' => 'nullable|string|in:Oro,Plata,Bronce,Mención honorífica',
+            'description' => 'string|nullable'
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Error in data validation',
+                'error' => $validator->errors(),
+                'status' => 400
+            ], 400);
+        }
+
+        $evaluation->classification_status = $request->classification_status;
+
+        if ($request->has('classification_place')) {
+            $evaluation->classification_place = $request->classification_place;
+        }
+
+        if ($request->has('description')) {
+            $evaluation->description = $request->description;
+        }
+
+        $evaluation->save();
+
+        return response()->json([
+            'message' => 'Classification status updated successfully',
+            'evaluation' => $evaluation,
+            'status' => 200
+        ], 200);
+    }
+
+    /**
+     * Get eligible competitors for a phase
+     */
+    private function getEligibleCompetitors($olympiadAreaPhase, $currentPhaseId)
+    {
+        // Para la primera fase (order = 1), todos los registrados pueden participar
+        $currentPhase = Phase::find($currentPhaseId);
+
+        if ($currentPhase->order == 1) {
+            // Primera fase: todos los evaluados en esta fase
+            return Evaluation::where('olympiad_area_phase_id', $olympiadAreaPhase->id)
+                ->with(['registration.contestant'])
+                ->get()
+                ->map(function($evaluation) {
+                    return $this->formatCompetitorData($evaluation);
+                });
+        } else {
+            // Fases posteriores: solo clasificados de la fase anterior
+            $previousPhaseOrder = $currentPhase->order - 1;
+
+            // Obtener registros que clasificaron en la fase anterior
+            $qualifiedRegistrations = $this->getQualifiedFromPreviousPhase(
+                $olympiadAreaPhase->olympiad_area_id,
+                $previousPhaseOrder
+            );
+
+            // Obtener evaluaciones de la fase actual para estos competidores
+            return Evaluation::where('olympiad_area_phase_id', $olympiadAreaPhase->id)
+                ->whereIn('registration_id', $qualifiedRegistrations)
+                ->with(['registration.contestant'])
+                ->get()
+                ->map(function($evaluation) {
+                    return $this->formatCompetitorData($evaluation);
+                });
+        }
+    }
+
+    /**
+     * Get registrations that qualified from previous phase
+     */
+    private function getQualifiedFromPreviousPhase($olympiadAreaId, $previousPhaseOrder)
+    {
+        return Evaluation::whereHas('olympiadAreaPhase', function($q) use ($olympiadAreaId, $previousPhaseOrder) {
+                $q->where('olympiad_area_id', $olympiadAreaId)
+                  ->whereHas('phase', function($phaseQuery) use ($previousPhaseOrder) {
+                      $phaseQuery->where('order', $previousPhaseOrder);
+                  });
+            })
+            ->where('classification_status', 'clasificado')
+            ->pluck('registration_id');
+    }
+
+    /**
+     * Format competitor data for response
+     */
+    private function formatCompetitorData($evaluation)
+    {
+        $contestant = $evaluation->registration->contestant ?? null;
+
+        return [
+            'evaluation_id' => $evaluation->id,
+            'registration_id' => $evaluation->registration_id,
+            'contestant_id' => $contestant->id ?? null,
+            'first_name' => $contestant->first_name ?? null,
+            'last_name' => $contestant->last_name ?? null,
+            'ci_document' => $contestant->ci_document ?? null,
+            'score' => $evaluation->score,
+            'description' => $evaluation->description,
+            'status' => $evaluation->status,
+            'classification_status' => $evaluation->classification_status,
+            'classification_place' => $evaluation->classification_place,
+        ];
     }
 }

--- a/app/Http/Controllers/Api/PhaseController.php
+++ b/app/Http/Controllers/Api/PhaseController.php
@@ -5,11 +5,15 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 
 use App\Models\Phase;
 use App\Models\OlympiadArea;
 use App\Models\OlympiadAreaPhase;
+use App\Models\Evaluation;
+use App\Models\OlympiadAreaPhaseLevelGrade;
+use App\Models\LevelGrade;
 
 /**
  * @OA\Tag(
@@ -419,6 +423,11 @@ class PhaseController extends Controller
             return response()->json($data, 500);
         }
 
+        // Si la fase se marca como "Terminada", procesar clasificaciones
+        if ($request->status === 'Terminada') {
+            $this->processPhaseClassifications($olympiadAreaPhase, $olympiadArea);
+        }
+
         // Cargar la información de la fase para la respuesta
         $olympiadAreaPhase->load('phase');
 
@@ -433,5 +442,160 @@ class PhaseController extends Controller
         ];
 
         return response()->json($data, 200);
+    }
+
+    /**
+     * Process automatic classification when a phase is marked as "Terminada"
+     */
+    private function processPhaseClassifications($olympiadAreaPhase, $olympiadArea)
+    {
+        // Obtener todas las evaluaciones de esta fase
+        $evaluations = Evaluation::where('olympiad_area_phase_id', $olympiadAreaPhase->id)
+            ->whereNotNull('score')
+            ->get();
+
+        // Verificar si es la fase final
+        $isFinalPhase = $this->isFinalPhase($olympiadAreaPhase, $olympiadArea);
+
+        // Obtener la siguiente fase si no es la final
+        $nextOlympiadAreaPhase = null;
+        if (!$isFinalPhase) {
+            $nextOlympiadAreaPhase = $this->getNextPhase($olympiadAreaPhase, $olympiadArea);
+        }
+
+        foreach ($evaluations as $evaluation) {
+            // Obtener score_cut para esta evaluación específica
+            $scoreCut = $this->getScoreCut($olympiadAreaPhase, $evaluation);
+
+            if ($scoreCut !== null) {
+                // Clasificar basado en score_cut
+                if ($evaluation->score >= $scoreCut) {
+                    $evaluation->classification_status = 'clasificado';
+
+                    // Si no es la fase final y el competidor clasifica, crear registro para siguiente fase
+                    if (!$isFinalPhase && $nextOlympiadAreaPhase) {
+                        $this->createNextPhaseEvaluation($evaluation, $nextOlympiadAreaPhase);
+                    }
+                } else {
+                    $evaluation->classification_status = 'desclasificado';
+                }
+            }
+        }
+
+        // Si es la fase final, asignar medallas
+        if ($isFinalPhase) {
+            $this->assignMedals($evaluations);
+        }
+
+        // Guardar todas las evaluaciones
+        foreach ($evaluations as $evaluation) {
+            $evaluation->save();
+        }
+    }
+
+    /**
+     * Get the score cut for a specific evaluation
+     */
+    private function getScoreCut($olympiadAreaPhase, $evaluation)
+    {
+        // Usar consulta SQL directa basada en la tabla contestant_level_grades
+        $scoreCut = DB::table('evaluations as e')
+            ->join('registrations as r', 'e.registration_id', '=', 'r.id')
+            ->join('contestant_level_grades as clg', 'r.contestant_id', '=', 'clg.contestant_id')
+            ->join('olympiad_area_phase_level_grades as oaplg', 'clg.level_grade_id', '=', 'oaplg.level_grade_id')
+            ->where('e.id', $evaluation->id)
+            ->value('oaplg.score_cut');
+
+        return $scoreCut;
+    }
+
+    /**
+     * Check if the current phase is the final phase for this olympiad area
+     */
+    private function isFinalPhase($currentOlympiadAreaPhase, $olympiadArea)
+    {
+        $maxOrder = OlympiadAreaPhase::where('olympiad_area_id', $olympiadArea->id)
+            ->join('phases', 'olympiad_area_phases.phase_id', '=', 'phases.id')
+            ->max('phases.order');
+
+        $currentPhase = $currentOlympiadAreaPhase->load('phase');
+
+        return $currentPhase->phase->order == $maxOrder;
+    }
+
+    /**
+     * Assign medals for the final phase
+     */
+    private function assignMedals($evaluations)
+    {
+        // Ordenar por puntuación descendente (solo clasificados)
+        $classifiedEvaluations = $evaluations
+            ->where('classification_status', 'clasificado')
+            ->sortByDesc('score')
+            ->values();
+
+        foreach ($classifiedEvaluations as $index => $evaluation) {
+            switch ($index) {
+                case 0:
+                    $evaluation->classification_place = 'Oro';
+                    break;
+                case 1:
+                    $evaluation->classification_place = 'Plata';
+                    break;
+                case 2:
+                    $evaluation->classification_place = 'Bronce';
+                    break;
+                default:
+                    $evaluation->classification_place = 'Mención honorífica';
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Get the next phase for this olympiad area
+     */
+    private function getNextPhase($currentOlympiadAreaPhase, $olympiadArea)
+    {
+        $currentPhase = $currentOlympiadAreaPhase->load('phase');
+        $nextPhaseOrder = $currentPhase->phase->order + 1;
+
+        // Buscar la siguiente fase en orden
+        $nextPhase = Phase::where('order', $nextPhaseOrder)->first();
+
+        if (!$nextPhase) {
+            return null;
+        }
+
+        // Buscar el OlympiadAreaPhase correspondiente para la siguiente fase
+        $nextOlympiadAreaPhase = OlympiadAreaPhase::where('olympiad_area_id', $olympiadArea->id)
+            ->where('phase_id', $nextPhase->id)
+            ->first();
+
+        return $nextOlympiadAreaPhase;
+    }
+
+    /**
+     * Create evaluation record for next phase when competitor qualifies
+     */
+    private function createNextPhaseEvaluation($currentEvaluation, $nextOlympiadAreaPhase)
+    {
+        // Verificar si ya existe un registro para este competidor en la siguiente fase
+        $existingEvaluation = Evaluation::where('registration_id', $currentEvaluation->registration_id)
+            ->where('olympiad_area_phase_id', $nextOlympiadAreaPhase->id)
+            ->first();
+
+        // Solo crear si no existe
+        if (!$existingEvaluation) {
+            Evaluation::create([
+                'registration_id' => $currentEvaluation->registration_id,
+                'olympiad_area_phase_id' => $nextOlympiadAreaPhase->id,
+                'score' => null,
+                'description' => null,
+                'status' => false,
+                'classification_status' => null,
+                'classification_place' => null
+            ]);
+        }
     }
 }

--- a/app/Models/Evaluation.php
+++ b/app/Models/Evaluation.php
@@ -14,7 +14,9 @@ class Evaluation extends Model
         'description',
         'registration_id',
         'olympiad_area_phase_id',
-        'status'
+        'status',
+        'classification_status',
+        'classification_place'
     ];
 
     /**

--- a/database/migrations/2025_11_12_042126_add_classification_fields_to_evaluations_table.php
+++ b/database/migrations/2025_11_12_042126_add_classification_fields_to_evaluations_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('evaluations', function (Blueprint $table) {
+            $table->enum('classification_status', ['clasificado', 'desclasificado', 'descalificado'])
+                  ->nullable()
+                  ->after('status');
+            $table->enum('classification_place', ['Oro', 'Plata', 'Bronce', 'Mención honorífica'])
+                  ->nullable()
+                  ->after('classification_status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('evaluations', function (Blueprint $table) {
+            $table->dropColumn(['classification_status', 'classification_place']);
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -135,6 +135,8 @@ Route::get('/csv-uploads/{id}/download-errors', [CsvUploadController::class, 'do
 // <--- CRUD Evaluation --->
 Route::patch('/evaluations/{id}',[EvaluationController::class, 'updatePartialEvaluation']);
 Route::get('/evaluations/check-updates/',[EvaluationController::class, 'checksUpdates']);
+Route::get('/olympiads/{olympiadId}/areas/{areaId}/phases/{phaseId}/competitors', [EvaluationController::class, 'getCompetitorsByPhase']);
+Route::patch('/evaluations/{id}/classification', [EvaluationController::class, 'updateClassificationStatus']);
 
 // <--- Get Contestants --->
 Route::get('/contestants/{phase_id}/{olympiad_id}/{area_id}/{level_id}', [ContestantController::class, 'showContestant']);

--- a/test_endpoints.md
+++ b/test_endpoints.md
@@ -1,0 +1,101 @@
+# Test Endpoints - Sistema de Clasificación
+
+## Nuevos Endpoints Implementados
+
+### 1. Obtener Competidores por Fase
+```
+GET /api/olympiads/{olympiadId}/areas/{areaId}/phases/{phaseId}/competitors
+```
+
+**Descripción**: Obtiene todos los competidores elegibles para una fase específica.
+- Para la primera fase: Todos los inscritos
+- Para fases posteriores: Solo clasificados de la fase anterior
+
+**Ejemplo de Respuesta**:
+```json
+{
+  "competitors": [
+    {
+      "evaluation_id": 1,
+      "registration_id": 1,
+      "contestant_id": 1,
+      "first_name": "Juan",
+      "last_name": "Pérez",
+      "ci_document": "12345678",
+      "score": 85,
+      "description": "Buen desempeño",
+      "status": true,
+      "classification_status": "clasificado",
+      "classification_place": "Oro"
+    }
+  ],
+  "olympiad_id": "1",
+  "area_id": "1", 
+  "phase_id": "1",
+  "status": 200
+}
+```
+
+### 2. Actualizar Estado de Clasificación
+```
+PATCH /api/evaluations/{id}/classification
+```
+
+**Descripción**: Permite actualizar manualmente el estado de clasificación de un competidor.
+
+**Body de Ejemplo**:
+```json
+{
+  "classification_status": "descalificado",
+  "description": "Comportamiento inadecuado durante la evaluación"
+}
+```
+
+## Funcionalidad Automática
+
+### Clasificación Automática
+Cuando se marca una fase como "Terminada", el sistema automáticamente:
+
+1. **Calcula el classification_status** basado en score_cuts:
+   - `clasificado`: score >= score_cut
+   - `desclasificado`: score < score_cut
+   - `descalificado`: manual (por motivos disciplinarios)
+
+2. **Asigna medallas** (solo en fase final):
+   - `Oro`: Mayor puntuación
+   - `Plata`: Segunda mayor puntuación  
+   - `Bronce`: Tercera mayor puntuación
+   - `Mención honorífica`: Resto de clasificados
+
+### Campos Agregados a la Tabla `evaluations`
+
+- `classification_status`: ENUM('clasificado', 'desclasificado', 'descalificado')
+- `classification_place`: ENUM('Oro', 'Plata', 'Bronce', 'Mención honorífica')
+
+## Estados de Clasificación
+
+1. **clasificado**: El competidor cumplió con el score_cut y puede pasar a la siguiente fase
+2. **desclasificado**: El competidor no cumplió con el score_cut 
+3. **descalificado**: El competidor fue descalificado por motivos disciplinarios o conducta
+
+## Flujo de Fases
+
+- **Fase 1**: Todos los inscritos pueden participar
+- **Fase 2+**: Solo los clasificados de la fase anterior
+- **Fase Final**: Clasificados + asignación automática de medallas
+
+## Casos de Uso
+
+1. **Evaluador consulta competidores**: 
+   - `GET /olympiads/1/areas/2/phases/1/competitors`
+
+2. **Se termina una fase**:
+   - `PUT /olympiads/1/areas/2/phase-status` con `status: "Terminada"`
+   - Sistema automáticamente clasifica y asigna medallas si es fase final
+
+3. **Descalificar un competidor manualmente**:
+   - `PATCH /evaluations/123/classification` con `classification_status: "descalificado"`
+
+4. **Consultar competidores para siguiente fase**:
+   - `GET /olympiads/1/areas/2/phases/2/competitors` 
+   - Solo retorna clasificados de fase anterior


### PR DESCRIPTION
Request:
PATCH /evaluations/{evaluationID}/classification

Body:
{
	"classification_status": "clasificado"|"desclasificado"|"descalificado"-> required
	"classification_place": "Oro"|"Plata"|"Bronce"|"Mención honorífica" -> nullable
	"description": "string" -> nullable
}

-------------------

Request:
GET /api/olympiads/{olympiadID}/areas/{areaID}/phases/{phaseID}/competitors

Response:
{
    "competitors": [
        {
            "evaluation_id": 8,
            "registration_id": 8,
            "contestant_id": 7,
            "first_name": "Pedro",
            "last_name": "Lopez",
            "ci_document": "11223344",
            "score": 60,
            "description": "asdf",
            "status": true,
            "classification_status": "clasificado",
            "classification_place": null
        },
        {
            "evaluation_id": 13,
            "registration_id": 13,
            "contestant_id": 10,
            "first_name": "Maria",
            "last_name": "Terrazas",
            "ci_document": "12323434",
            "score": 65,
            "description": "asdf",
            "status": true,
            "classification_status": "clasificado",
            "classification_place": null
        },
        {
            "evaluation_id": 15,
            "registration_id": 15,
            "contestant_id": 11,
            "first_name": "Pablo",
            "last_name": "Torrico",
            "ci_document": "18592365",
            "score": 35,
            "description": "asdf",
            "status": true,
            "classification_status": "desclasificado",
            "classification_place": null
        }
    ],
    "olympiad_id": "3",
    "area_id": "2",
    "phase_id": "1",
    "status": 200
}