### PR TITLE
feat: single phase status getter

### DIFF
--- a/app/Http/Controllers/Api/PhaseController.php
+++ b/app/Http/Controllers/Api/PhaseController.php
@@ -232,6 +232,76 @@ class PhaseController extends Controller
         return response()->json($data, 200);
     }
 
+    public function getSinglePhaseStatus(string $olympiadId, string $areaId, string $levelId, string $phaseId)
+    {
+        // Verify that the olympiad_area relationship exists
+        $olympiadArea = OlympiadArea::where('olympiad_id', $olympiadId)
+            ->where('area_id', $areaId)
+            ->first();
+
+        if (!$olympiadArea) {
+            return response()->json([
+                'message' => 'Olympiad area relationship not found',
+                'status' => 404
+            ], 404);
+        }
+
+        // Verify that the level_grade exists for this level and olympiad_area
+        $levelGrade = LevelGrade::where('olympiad_area_id', $olympiadArea->id)
+            ->where('level_id', $levelId)
+            ->first();
+
+        if (!$levelGrade) {
+            return response()->json([
+                'message' => 'Level not found for this olympiad area',
+                'status' => 404
+            ], 404);
+        }
+
+        // Verify that the phase exists for this olympiad area
+        $olympiadAreaPhase = OlympiadAreaPhase::where('olympiad_area_id', $olympiadArea->id)
+            ->where('phase_id', $phaseId)
+            ->with('phase')
+            ->first();
+
+        if (!$olympiadAreaPhase) {
+            return response()->json([
+                'message' => 'Phase not found for this olympiad area',
+                'status' => 404
+            ], 404);
+        }
+
+        // Get the specific phase status for this level
+        $oaplg = OlympiadAreaPhaseLevelGrade::where('olympiad_area_phase_id', $olympiadAreaPhase->id)
+            ->where('level_grade_id', $levelGrade->id)
+            ->first();
+
+        if (!$oaplg) {
+            return response()->json([
+                'message' => 'Phase status configuration not found for this level',
+                'error' => 'Please configure this phase for the specified level first.',
+                'status' => 404
+            ], 404);
+        }
+
+        $phaseStatus = [
+            'phase_id' => (int)$phaseId,
+            'phase_name' => $olympiadAreaPhase->phase->name,
+            'phase_order' => $olympiadAreaPhase->phase->order,
+            'status' => $oaplg->status,
+            'score_cut' => $oaplg->score_cut,
+            'max_score' => $oaplg->max_score
+        ];
+
+        return response()->json([
+            'olympiad_id' => (int)$olympiadId,
+            'area_id' => (int)$areaId,
+            'level_id' => (int)$levelId,
+            'phase_status' => $phaseStatus,
+            'status' => 200
+        ], 200);
+    }
+
     public function updatePhaseStatus(Request $request, string $olympiadId, string $areaId, string $levelId)
     {
         // Data validation

--- a/routes/api.php
+++ b/routes/api.php
@@ -61,6 +61,7 @@ Route::delete('/phases/{id}', [PhaseController::class, 'destroy']);
 
 // <--- CRUD Olympiad-Area-Phases (Status) --->
 Route::get('/olympiads/{olympiadId}/areas/{areaId}/levels/{levelId}/phase-status', [PhaseController::class, 'getPhaseStatus']);
+Route::get('/olympiads/{olympiadId}/areas/{areaId}/levels/{levelId}/phases/{phaseId}/status', [PhaseController::class, 'getSinglePhaseStatus']);
 Route::put('/olympiads/{olympiadId}/areas/{areaId}/levels/{levelId}/phase-status', [PhaseController::class, 'updatePhaseStatus']);
 Route::put('/olympiads/{olympiadId}/areas/{areaId}/levels/{levelId}/phases/{phaseId}/endorse', [PhaseController::class, 'endorsePhase']);
 Route::put('/olympiads/{olympiadId}/areas/{areaId}/phases/{phaseId}/endorse-all-levels', [PhaseController::class, 'endorsePhaseAllLevels']);


### PR DESCRIPTION
GET /api//olympiads/{olympiadId}/areas/{areaId}/levels/{levelId}/phases/{phaseId}/status

{
    "olympiad_id": 3,
    "area_id": 2,
    "level_id": 4,
    "phase_status": {
        "phase_id": 1,
        "phase_name": "Fase 1",
        "phase_order": 1,
        "status": "Terminada",
        "score_cut": 51,
        "max_score": 100
    },
    "status": 200
}